### PR TITLE
Both credentials properly escaped to ensure correct format for RestClient

### DIFF
--- a/lib/document_cloud/configurable.rb
+++ b/lib/document_cloud/configurable.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 module DocumentCloud
   module Configurable
     attr_writer :email, :password
@@ -12,6 +13,7 @@ module DocumentCloud
     def configure
       yield self
       format_email!
+      format_password!
       self
     end
     
@@ -27,7 +29,10 @@ module DocumentCloud
     
       # Ensure email is correct format for RestClient posts
       def format_email!
-        @email.gsub!(/@/, "%40")
+        @email = CGI.escape @email
+      end
+      def format_password!
+        @password = CGI.escape @password
       end
     
   end


### PR DESCRIPTION
Considering passwords could also have special characters, escaping it is
also necessary. CGI library required.
