### PR TITLE
Coerce `document_id` to integer

### DIFF
--- a/lib/document_cloud/api/destroy.rb
+++ b/lib/document_cloud/api/destroy.rb
@@ -14,7 +14,7 @@ module DocumentCloud
       private
             
         def document_path(document_id)
-          "#{DOCUMENT_PATH}/#{document_id.to_s}.json"
+          "#{DOCUMENT_PATH}/#{document_id.to_i}.json"
         end
       
     end

--- a/lib/document_cloud/api/document.rb
+++ b/lib/document_cloud/api/document.rb
@@ -15,7 +15,7 @@ module DocumentCloud
       private
             
         def document_path(document_id)
-          "#{DOCUMENT_PATH}/#{document_id.to_s}.json"
+          "#{DOCUMENT_PATH}/#{document_id.to_i}.json"
         end
       
     end

--- a/lib/document_cloud/api/entities.rb
+++ b/lib/document_cloud/api/entities.rb
@@ -16,7 +16,7 @@ module DocumentCloud
       private
             
         def entities_path(document_id)
-          "#{DOCUMENT_PATH}/#{document_id.to_s}/#{ENTITIES_PATH}"
+          "#{DOCUMENT_PATH}/#{document_id.to_i}/#{ENTITIES_PATH}"
         end
       
     end

--- a/lib/document_cloud/api/update.rb
+++ b/lib/document_cloud/api/update.rb
@@ -24,7 +24,7 @@ module DocumentCloud
       private
             
         def document_path(document_id)
-          "#{DOCUMENT_PATH}/#{document_id.to_s}.json"
+          "#{DOCUMENT_PATH}/#{document_id.to_i}.json"
         end
       
     end

--- a/lib/document_cloud/api/update_project.rb
+++ b/lib/document_cloud/api/update_project.rb
@@ -20,7 +20,7 @@ module DocumentCloud
       private
             
         def project_path(project_id)
-          "#{PROJECT_PATH}/#{project_id.to_s}.json"
+          "#{PROJECT_PATH}/#{project_id.to_i}.json"
         end
       
     end


### PR DESCRIPTION
Hi,

I've run into an issue with document ids which contain macron characters, and would like to propose this pull request as a solution.

Document ids can be strings with additional slug elements which the DocumentCloud Rails app API coerces to an integer to find the actual record.

The DocumentCloud Rails app does so here:

https://github.com/documentcloud/documentcloud/blob/2dc6534ac9e2eea7135497d0135a6dc50e4252e4/app/controllers/api_controller.rb#L257

The feature of the Ruby language it relies on is that any string starting with a number will be truncated at the first non-numerical character when `to_i` is called on that string.

For example:

``` ruby
'123-abc'.to_i # => 123
```
##### Why is this an issue?

Document id slugs can include UTF8 characters. I ran into this issue with Document ids like:

'2713540-Ōrākei-Local-Board-20151210'

due to the macrons with Māori place names.

This generated an `URI::InvalidURIError: URI must be ascii only` exception.

You can test reproducing this exception with:

``` ruby
DocumentCloud.document('123-Māngere-Ōtāhuhu')
```

Hopefully this helps.

Thanks!
- Caleb
